### PR TITLE
Dial back dependabot updates to monthly+major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly 
+      interval: monthly
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-patch']


### PR DESCRIPTION
Reduce dependabot npm frequency to monthly, limit automatic updates to major+minor.