### PR TITLE
Try running with node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: 'nFPM CLI version'
     default: '2.11.0'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Hiya. Currently builds that use this action throw a warning that says:

> The following actions uses node12 which is deprecated and will be forced to run on node16: secondlife/setup-nfpm@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The [linked help](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions) suggests setting `node16` as the runtime for JavaScript actions. Should this work? The tests seem to think so. Could we give this a go maybe? Thanks!