### PR TITLE
Add update-major-tag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag:
+    name: Tag
+    uses: secondlife/update-major-tag-workflow/.github/workflows/update-major-tag.yaml@v1


### PR DESCRIPTION
Automatically bump major version tag after release.