### PR TITLE
Install nFPM 2.45 by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: Linden Lab
 inputs:
   version:
     description: 'nFPM CLI version'
-    default: '2.33.1'
+    default: '2.45.2'
 
 runs:
   using: node24


### PR DESCRIPTION
Let's update the version of nFPM we install by default. There should be no backward incompatible changes between 2.33.1 & 2.45.2. Lg?